### PR TITLE
Add attributes for class-Token

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ set(GBC_SRC
         src/include/lex/dfa.h
         src/include/lex/lexical_analyzer.h
         src/include/lex/nfa.h
-        src/lex/rules.cc src/include/lex/rules.h
-        src/grammar/grammar_analyzer.cc src/include/grammar/grammar_analyzer.h src/grammar/grammar_parser.cc src/include/grammar/grammar_parser.h src/grammar/ll_1_parser.cc src/include/grammar/ll_1_parser.h
-        src/lex/alphabet.cpp src/include/lex/alphabet.h src/lex/nfa.cc src/lex/dfa.cc src/lex/dfa.cc src/lex/lexical_analyzer.cc)
+        src/lex/rules.cc
+        src/include/lex/rules.h
+        src/grammar/grammar_analyzer.cc src/include/grammar/grammar_analyzer.h
+        src/grammar/grammar_parser.cc src/include/grammar/grammar_parser.h
+        src/grammar/ll_1_parser.cc src/include/grammar/ll_1_parser.h
+        src/lex/alphabet.cc src/include/lex/alphabet.h
+        src/lex/nfa.cc src/lex/dfa.cc src/lex/lexical_analyzer.cc)
 
 add_executable(${PROJECT_NAME} ${GBC_SRC})
 

--- a/src/include/lex/alphabet.h
+++ b/src/include/lex/alphabet.h
@@ -12,11 +12,22 @@ namespace gbc::lex {
 
     class Alphabet {
     public:
-        std::set<char> _alphabet;
+        Alphabet() = default;
+
+        ~Alphabet() = default;
+
         void initiate();
-        bool isInAlphabet(char &c); // check if c is in alphabet
-        bool append(char &c); // add new character to alphabet
-        // iterator for Alphabet
+
+        bool has(const char &c);
+
+        bool insert(const char &c);
+
+        std::set<char>::iterator begin();
+
+        std::set<char>::iterator end();
+
+    private:
+        std::set<char> _alphabet;
 
     };
 

--- a/src/include/lex/token.h
+++ b/src/include/lex/token.h
@@ -10,25 +10,38 @@
 
 namespace gbc::lex {
     using token_id = long long;
-    typedef std::string token_name;
-    typedef std::string token_pattern;
+    using token_name = std::string;
+    using token_pattern = std::string;
+    using attribute_t = std::string;
 
     class Token {
+    public:
+        Token();
+
+        Token(token_id, token_name, token_pattern);
+
+        [[nodiscard]] token_id id() const;
+
+        token_name name();
+
+        token_pattern pattern();
+
+        attribute_t type();
+
+        attribute_t value();
+
+        bool update_pattern(token_pattern);
+
+        bool infix_to_postfix();
+
+        bool operator<(const Token &X) const;
+
     private:
         token_id _id;
         token_name _name;
         token_pattern _pattern;
-    public:
-        Token();
-        Token(token_id, token_name, token_pattern);
-
-        [[nodiscard]] token_id id() const;
-        token_name name();
-        token_pattern pattern();
-
-        bool update_pattern(token_pattern);
-        bool infix_to_postfix();
-        bool operator<(const Token &X) const;
+        attribute_t _type;
+        attribute_t _value;
     };
 
     bool isRegexCharacter(char c);

--- a/src/lex/alphabet.cc
+++ b/src/lex/alphabet.cc
@@ -13,14 +13,22 @@ namespace gbc::lex {
         }
     }
 
-    bool Alphabet::isInAlphabet(char &c) {
+    bool Alphabet::has(const char &c) {
         return this->_alphabet.find(c) != this->_alphabet.end();
     }
 
-    bool Alphabet::append(char &c) {
-        if(this->isInAlphabet(c)) return false;
+    bool Alphabet::insert(const char &c) {
+        if(this->has(c)) return false;
         this->_alphabet.insert(c);
         return true;
+    }
+
+    std::set<char>::iterator Alphabet::begin() {
+        return this->_alphabet.begin();
+    }
+
+    std::set<char>::iterator Alphabet::end() {
+        return this->_alphabet.end();
     }
 
 } // gbc::lex namespace

--- a/src/lex/dfa.cc
+++ b/src/lex/dfa.cc
@@ -21,7 +21,7 @@ namespace gbc::lex {
                 if (isMarked.find(T) == isMarked.end()) {
                     // found unmarked state T
                     isMarked[T] = true;
-                    for (auto a: this->alphabet._alphabet) {
+                    for (auto a: this->alphabet) {
                         std::set<int> U = epsilon_closure(move(T, a, N), N);
                         if (U.empty()) continue; // !exsist U=move(T,a), then nothing to do
                         if (this->Dstates.find(U) == this->Dstates.end()) {
@@ -159,7 +159,7 @@ namespace gbc::lex {
         }
         // define transition table
         for (auto s: dfa.Dstates) {
-            for (auto c: D.alphabet._alphabet) {
+            for (auto c: D.alphabet) {
                 DFAState t = D.trans(s, c);
                 if (t.size() > 0) dfa.Dtrans[{Repr[PartitionID[s]], c}] = Repr[PartitionID[t]];
             }
@@ -197,7 +197,7 @@ namespace gbc::lex {
         std::map<std::vector<int>, std::set<DFAState>> subsets;
         for (auto g: G) {
             std::vector<int> v;
-            for (auto c: D.alphabet._alphabet) v.push_back(PartitionID[D.trans(g, c)]);
+            for (auto c: D.alphabet) v.push_back(PartitionID[D.trans(g, c)]);
             subsets[v].insert(g);
         }
         // show_vectorization(subsets);
@@ -212,7 +212,7 @@ namespace gbc::lex {
     void show_DFA(DFA &D) {
         std::cerr << "alphabet============================" << std::endl;
         short new_line = 10;
-        for (char c: D.alphabet._alphabet) {
+        for (auto c: D.alphabet) {
             std::cerr << c << " ";
             if (--new_line == 0) {
                 std::cerr << std::endl;
@@ -264,7 +264,7 @@ namespace gbc::lex {
             DFAState state = states.top();
             char c = input[i];
             // std::cerr << "current char:" << c << std::endl;
-            if (M.alphabet._alphabet.find(c) == M.alphabet._alphabet.end()) {
+            if (!M.alphabet.has(c)) {
                 std::cerr << "ERROR: character " << c <<"(" <<(int)c << ") not in alphabet" << std::endl;
                 exit(1);
             }

--- a/src/lex/token.cc
+++ b/src/lex/token.cc
@@ -27,6 +27,14 @@ namespace gbc::lex {
         return this->_pattern;
     }
 
+    attribute_t Token::type() {
+        return this->_type;
+    }
+
+    attribute_t Token::value() {
+        return this->_value;
+    }
+
     bool Token::operator<(const Token &X) const {
         return this->_id < X._id;
     }

--- a/test/lex/alphabet_test.cc
+++ b/test/lex/alphabet_test.cc
@@ -1,0 +1,42 @@
+//
+// Created by Eric2i Hsiung on 2023/6/18.
+//
+
+#include "../../src/include/lex/alphabet.h"
+#include <iostream>
+#include <set>
+
+namespace gbc::lex {
+    bool alphabet_tester() {
+        Alphabet alphabet;
+        // insert several chars and test isInAlphabet
+
+        // test append
+        alphabet.insert('a');
+        alphabet.insert('b');
+        alphabet.insert('c');
+
+
+        // test isInAlphabet
+        assert(alphabet.has('a'));
+        assert(alphabet.has('b'));
+        assert(alphabet.has('c'));
+
+
+        // test begin() and end()
+        auto iter = alphabet.begin();
+        assert(*iter == 'a');
+        iter++;
+        assert(*iter == 'b');
+        iter++;
+        assert(*iter == 'c');
+        iter++;
+        assert(iter == alphabet.end());
+
+        // test initiate()
+        alphabet.initiate();
+        for (auto i: alphabet) std::cerr << i << " ";
+
+        return true;
+    }
+}

--- a/test/lex/analyzer_test.cc
+++ b/test/lex/analyzer_test.cc
@@ -13,9 +13,9 @@ namespace gbc::lex {
         std::cerr << "building DFA..." << std::endl; DFA dfa; dfa.NFA2DFA(nfa);
         std::cerr << "Minimizing DFA..." << std::endl;DFA minDFA = DFAMinimize(dfa);
 //        show_DFA(minDFA);
-
         path src = "../test/lex/sourceCode.txt";
         LexicalAnalyzer analyzer(minDFA);
         std::cerr << "Parsing Source Codes..." << std::endl; auto result = analyzer.parse(src);
+        return true;
     }
 }


### PR DESCRIPTION
Adding two attributes for each token and you could visit them via following member functions:
- .type() -> std::string
- .value() -> std::string

All attributes' data type is std::string by default currently.